### PR TITLE
mp-29 Configure Ingredient Controller admin only

### DIFF
--- a/app/controllers/ingredients_controller.rb
+++ b/app/controllers/ingredients_controller.rb
@@ -26,7 +26,9 @@ class IngredientsController < OpenReadController
 
   # PATCH/PUT /ingredients/1
   def update
-    if @ingredient.update(ingredient_params)
+    if !current_user.admin
+      render status: :unauthorized
+    elsif @ingredient.update(ingredient_params)
       render json: @ingredient
     else
       render json: @ingredient.errors, status: :unprocessable_entity
@@ -35,7 +37,11 @@ class IngredientsController < OpenReadController
 
   # DELETE /ingredients/1
   def destroy
-    @ingredient.destroy
+    if !current_user.admin
+      render status: :unauthorized
+    else
+      @ingredient.destroy
+    end
   end
 
   private

--- a/app/models/ingredient.rb
+++ b/app/models/ingredient.rb
@@ -1,4 +1,4 @@
 class Ingredient < ApplicationRecord
-  has_many :recipe_ingredients
-  has_many :recipes, through: :recipe_ingredients
+  has_many :recipe_ingredients, dependent: :destroy
+  has_many :recipes, through: :recipe_ingredients, dependent: :destroy
 end


### PR DESCRIPTION
-(feature) Configure Ingredient Controller so only admin can update or
           delete
-(refactor) Update Ingredient model with dependent destroy macros

Closes: #29 